### PR TITLE
fix: writer index was not updated via extension property

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This project contains various [extension methods and properties](src/main/kotlin
 
 ## Unreleased
 
+### Fixed
+
+* writer index was not updated when using `writerIndex` extension property;
+
 ### Updated:
 
 * th2 bom now `4.11.0` that comes from th2 gradle plugins `0.2.4`

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Netty ByteBuf Util (0.2.0)
+# Netty ByteBuf Util (0.3.0)
 
 This project contains various [extension methods and properties](src/main/kotlin/com/exactpro/th2/netty/bytebuf/util/ByteBufUtil.kt) for Netty's ByteBuf
 
 # Changelog
 
-## Unreleased
+## 0.3.0
 
 ### Fixed
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-release_version=0.2.0
+release_version=0.2.1
 kotlin.code.style=official
 description='Set of useful extension methods and properties for Netty's ByteBuf'
 vcs_url=https://github.com/th2-net/th2-netty-bytebuf-utils

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-release_version=0.2.1
+release_version=0.3.0
 kotlin.code.style=official
 description='Set of useful extension methods and properties for Netty's ByteBuf'
 vcs_url=https://github.com/th2-net/th2-netty-bytebuf-utils

--- a/src/main/kotlin/com/exactpro/th2/netty/bytebuf/util/ByteBufUtil.kt
+++ b/src/main/kotlin/com/exactpro/th2/netty/bytebuf/util/ByteBufUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ * Copyright 2023-2025 Exactpro (Exactpro Systems Limited)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/exactpro/th2/netty/bytebuf/util/ByteBufUtil.kt
+++ b/src/main/kotlin/com/exactpro/th2/netty/bytebuf/util/ByteBufUtil.kt
@@ -63,7 +63,7 @@ var ByteBuf.readerIndex: Int
 var ByteBuf.writerIndex: Int
     get() = writerIndex()
     set(value) {
-        writerIndex()
+        writerIndex(value)
     }
 
 fun ByteBuf.shiftReaderIndex(shift: Int): ByteBuf = apply { readerIndex += shift }

--- a/src/test/kotlin/com/exactpro/th2/netty/bytebuf/util/ByteBufUtilTest.kt
+++ b/src/test/kotlin/com/exactpro/th2/netty/bytebuf/util/ByteBufUtilTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.exactpro.th2.netty.bytebuf.util
 
 import io.netty.buffer.Unpooled

--- a/src/test/kotlin/com/exactpro/th2/netty/bytebuf/util/ByteBufUtilTest.kt
+++ b/src/test/kotlin/com/exactpro/th2/netty/bytebuf/util/ByteBufUtilTest.kt
@@ -1,0 +1,29 @@
+package com.exactpro.th2.netty.bytebuf.util
+
+import io.netty.buffer.Unpooled
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ByteBufUtilTest {
+    @Test
+    fun `writer index is updated via property`() {
+        val buffer = Unpooled.buffer(10)
+        assertEquals(0, buffer.writerIndex(), "initial write index must be 0")
+
+        buffer.writerIndex = 4
+
+        assertEquals(4, buffer.writerIndex(), "write index was not updated")
+    }
+
+    @Test
+    fun `reader index is updated via property`() {
+        val buffer = Unpooled.buffer(10)
+            .writeLong(42L)
+
+        assertEquals(0, buffer.readerIndex(), "initial reader index must be 0")
+
+        buffer.readerIndex = 4
+
+        assertEquals(4, buffer.readerIndex(), "reader index was not updated")
+    }
+}


### PR DESCRIPTION
The problem was introduced in #6

The PR is ready for review, but should not be merged until we modify the workflows and migrate to th2 gradle plugins (will be done in separate PRs)